### PR TITLE
fix(delegate): leave install-on-quit updates with Sparkle

### DIFF
--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -378,6 +378,11 @@ export const onWillRelaunchApplication = createListener<WillRelaunchApplicationP
 export const onUserDidMakeChoice = createListener<UserDidMakeChoicePayload>(Events.USER_DID_MAKE_CHOICE);
 export const onWillScheduleUpdateCheck = createListener<WillScheduleUpdateCheckPayload>(Events.WILL_SCHEDULE_UPDATE_CHECK);
 export const onWillNotScheduleUpdateCheck = createListener<WillNotScheduleUpdateCheckPayload>(Events.WILL_NOT_SCHEDULE_UPDATE_CHECK);
+/**
+ * An automatically downloaded update has been staged and will be installed
+ * when the app quits. Informational: Sparkle keeps responsibility for the
+ * install and for reminding the user if the app stays open for a long time.
+ */
 export const onWillInstallUpdateOnQuit = createListener<WillInstallUpdateOnQuitPayload>(Events.WILL_INSTALL_UPDATE_ON_QUIT);
 
 const ALL_EVENTS = Object.values(Events);

--- a/src/sparkle/delegate.rs
+++ b/src/sparkle/delegate.rs
@@ -229,6 +229,13 @@ define_class!(
             true
         }
 
+        /// Sparkle asks whether the host takes over an update it downloaded
+        /// automatically and staged for install on quit. Returning `YES`
+        /// hands Sparkle's follow-ups to the host: the reminder it shows when
+        /// the app has not quit for `SUScheduledImpatientCheckInterval`, and
+        /// the immediate presentation of critical updates. The plugin has no
+        /// UI to replace them and does not expose the install block, so the
+        /// event stays informational and Sparkle keeps responsibility.
         #[unsafe(method(updater:willInstallUpdateOnQuit:immediateInstallationBlock:))]
         fn updater_will_install_update_on_quit(
             &self,
@@ -239,7 +246,7 @@ define_class!(
             self.emit(EVENT_WILL_INSTALL_UPDATE_ON_QUIT, &VersionInfo {
                 version: item.display_version_string().to_string(),
             });
-            true
+            false
         }
 
         #[unsafe(method(allowedChannelsForUpdater:))]


### PR DESCRIPTION
`updater:willInstallUpdateOnQuit:immediateInstallationBlock:` returned `YES`, which tells Sparkle the host app takes over the staged update. The plugin only emitted an event and dropped the install block, so Sparkle skipped its own follow-ups: the reminder for apps that stay open past `SUScheduledImpatientCheckInterval` and the immediate presentation of critical updates. Hosts that ignore the event never get prompted, and background apps rarely quit.

Return `NO` so Sparkle keeps responsibility. The `will-install-update-on-quit` event is still emitted and is documented as informational on the JS side.

Tests: `cargo test` with `SPARKLE_FRAMEWORK_PATH` and `DYLD_FRAMEWORK_PATH` set, 9 passed.

