### PR TITLE
ci(release): point semver checks at the downloaded Sparkle framework

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          # release-plz 0.3.164+ runs cargo-semver-checks on a temporary copy
+          # of the crate, so build.rs cannot find the framework downloaded
+          # into the workspace unless told where it is.
+          SPARKLE_FRAMEWORK_PATH: ${{ github.workspace }}
 
   publish-npm:
     name: Publish to npm


### PR DESCRIPTION
The Release workflow failed on master after #17: release-plz 0.3.164 runs `cargo-semver-checks` on a temporary copy of the crate, and `build.rs` only searches `SPARKLE_FRAMEWORK_PATH`, a `src-tauri` ancestor, and the manifest directory. The framework downloaded into the workspace root is none of those from the copy, so the build script panics with "Sparkle.framework not found". The last successful release ran release-plz 0.3.160, which checked the crate in place.

Set `SPARKLE_FRAMEWORK_PATH` to the workspace on the release-plz step so every build the action starts finds the framework.

